### PR TITLE
Add dependabot config for pip dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Opens the PRs visible here https://github.com/dbast/conda-bots/pulls

This should silence the security warnings https://github.com/conda/conda-bots/security/dependabot